### PR TITLE
chore(jest): remove lucide-react in jest module mapper

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,4 @@
 import nextJest from "next/jest.js";
-import { createRequire } from "node:module";
-
-const require = createRequire(import.meta.url);
 
 const createJestConfig = nextJest({
   dir: "./",
@@ -30,8 +27,6 @@ const customJestConfig = {
   testEnvironment: "jest-environment-jsdom",
   testPathIgnorePatterns: ["<rootDir>/e2e/"],
   moduleNameMapper: {
-    // https://github.com/lucide-icons/lucide/issues/2734#issuecomment-2597970172
-    "lucide-react": require.resolve("lucide-react"),
     "^~/(.*)$": "<rootDir>/src/$1",
   },
 };


### PR DESCRIPTION
* issue with lucide-react has been resolved on their end and the module map is no longer necessary